### PR TITLE
Add `inspect!` macro.

### DIFF
--- a/src/inspect.rs
+++ b/src/inspect.rs
@@ -1,0 +1,93 @@
+//! Inspect Macros
+
+/// Evaluates an expression, prints a stringified version of the expression
+/// along with the evaluated value, and then returns that value.
+///
+/// # Example
+///
+/// ```
+/// # #[macro_use] extern crate mac;
+///
+/// # fn main() {
+/// fn lcm_2_to_4() -> u32 {
+///     let mut i = 1;
+///     loop {
+///         if inspect!(i % 2, i % 3, i % 4) == (0, 0, 0) {
+///             return inspect!("done: i = " => i);
+///         }
+///         i += 1;
+///     }
+/// }
+/// assert_eq!(lcm_2_to_4(), 12);
+/// # }
+/// ```
+///
+/// Returns `12`, and prints the following to stdout:
+///
+/// ```ignore
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (1, 1, 1)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (0, 2, 2)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (1, 0, 3)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (0, 1, 0)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (1, 2, 1)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (0, 0, 2)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (1, 1, 3)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (0, 2, 0)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (1, 0, 1)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (0, 1, 2)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (1, 2, 3)
+/// src/inspect.rs:94 - (i % 2, i % 3, i % 4) = (0, 0, 0)
+/// src/inspect.rs:95 - done: i = 12
+/// ```
+
+#[macro_export]
+macro_rules! inspect {
+    ($prefix:expr => $expr:expr) => {{
+        let val = $expr;
+        println!("{}:{} - {}{:?}", file!(), line!(), $prefix, val);
+        val
+    }};
+    ($expr:expr) => {
+        inspect!(concat!(stringify!($expr), " = ") => $expr)
+    };
+    ($prefix:expr => $($expr:expr),+) => {
+        inspect!($prefix => ($($expr),+))
+    };
+    ($($expr:expr),+) => {
+        inspect!(($($expr),+))
+    };
+}
+
+#[test]
+fn test_inspect() {
+    assert_eq!(inspect!("foo"), "foo");
+    assert_eq!(inspect!("" => "foo"), "foo");
+    assert_eq!(inspect!(1 + 2, 2 + 3, 3 + 4), (3, 5, 7));
+    assert_eq!(inspect!("" => 1 + 2, 2 + 3, 3 + 4), (3, 5, 7));
+
+    fn fib(n: u64) -> u64 {
+        inspect!("fib :: n = " => n);
+        inspect! { "ret = " => match n {
+            0 | 1 => n,
+            n => fib(n-1) + fib(n-2)
+        }}
+    }
+
+    fn fib_iter(n: u64) -> u64 {
+        inspect!("fib_iter :: n = " => n);
+        let (mut a, mut b) = (0, 1);
+        for _ in 0..n {
+            inspect!(a, b);
+            let tmp = b;
+            b += a;
+            a = tmp;
+        }
+        inspect!("ret = " => a)
+    }
+
+    assert_eq!(fib(4), 3);
+    assert_eq!(fib_iter(7), 13);
+
+    // Uncomment the following to see the output in `cargo test`.
+    // panic!()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod mem;
 pub mod format;
 pub mod syntax_ext;
 pub mod matches;
+pub mod inspect;
 
 /// Unwraps an `Option` or returns from the function with the specified return
 /// value.


### PR DESCRIPTION
This is inspired a bit by `Debug.Trace.trace` in Haskell, which accepts a string and a value, prints the string, and then returns the value, so you can easily put it around any expression while debugging.

I'm open to suggestions about changes to the name, syntax, return values, or anything else.

Unresolved Question: Should I print everything to stdout or stderr?

FYI, this is the output for the `fib` and `fib_iter` tests:

```
fib :: n = 4
fib :: n = 3
fib :: n = 2
fib :: n = 1
ret = 1
fib :: n = 0
ret = 0
ret = 1
fib :: n = 1
ret = 1
ret = 2
fib :: n = 2
fib :: n = 1
ret = 1
fib :: n = 0
ret = 0
ret = 1
ret = 3
fib_iter :: n = 7
(a, b) = (0, 1)
(a, b) = (1, 1)
(a, b) = (1, 2)
(a, b) = (2, 3)
(a, b) = (3, 5)
(a, b) = (5, 8)
(a, b) = (8, 13)
ret = 13
```
