### PR TITLE
Add possibility to use `break` and `continue` in `do_while!`

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -18,11 +18,15 @@
 ///
 /// ```
 /// # #[macro_use] extern crate mac;
+/// # use std::borrow::Cow;
 /// # fn main() {
 /// let formatted = format_if!(true, "Vague error", "Error code {:?}", 3);
 ///
 /// assert_eq!(&formatted[..], "Error code 3");
-/// assert!(formatted.is_owned());
+/// match formatted {
+///     Cow::Owned(..) => {},
+///     _ => panic!("not owned"),
+/// }
 ///
 /// let not_formatted = format_if!(false, "Vague error", "Error code {:?}", {
 ///     // Note that the argument is not evaluated.
@@ -30,7 +34,10 @@
 /// });
 ///
 /// assert_eq!(&not_formatted[..], "Vague error");
-/// assert!(not_formatted.is_borrowed())
+/// match not_formatted {
+///     Cow::Borrowed(..) => {},
+///     _ => panic!("not borrowed"),
+/// }
 /// # }
 /// ```
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,9 +63,35 @@ macro_rules! unwrap_or_return {
 /// assert!(ran);
 /// # }
 /// ```
+///
+/// `break` and `continue` work as in other loops.
+///
+/// ```
+/// # #[macro_use] extern crate mac;
+/// # fn main() {
+/// let mut i = 0;
+/// do_while!({
+///     if i == 0 {
+///         i += 1;
+///         continue;
+///     } else if i == 2 {
+///         break;
+///     } else {
+///         i += 1;
+///     }
+/// } while i != 0);
+/// assert_eq!(i, 2);
+/// # }
+/// ```
 #[macro_export]
 macro_rules! do_while {
     ($body:block while $condition:expr) => {
-        while { $body; $condition } { }
+        {
+            let mut __do_while_ran = false;
+            while !__do_while_ran || $condition {
+                __do_while_ran = true;
+                $body
+            }
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,9 +87,9 @@ macro_rules! unwrap_or_return {
 macro_rules! do_while {
     ($body:block while $condition:expr) => {
         {
-            let mut __do_while_ran = false;
-            while !__do_while_ran || $condition {
-                __do_while_ran = true;
+            let mut ran = false;
+            while !ran || $condition {
+                ran = true;
                 $body
             }
         }


### PR DESCRIPTION
```
Add possibility to use `break` and `continue` in `do_while!`
```

This is done using a variable that tracks whether the loop already
executed. This allows using `break` and `continue` in the body of the
loop. It would be preferable to express the do-while-loop as

```
loop {
    $body
    if $cond {
        break;
    }
}
```

however, this does not work well because of the interaction with
`continue`.

This is a breaking change due to interactions with initialization
tracking, because `rustc` can no longer see that the body is guaranteed
to execute.
