### PR TITLE
Bump to 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mac"
-version = "0.0.2"
+version = "0.1.0"
 authors = ["Jonathan Reem <jonathan.reem@gmail.com>"]
 repository = "https://github.com/reem/rust-mac.git"
 description = "A collection of great and ubiqutitous macros."


### PR DESCRIPTION
ref:https://github.com/servo/servo/issues/15224
Bump to 0.1.0 to avoid incompatible matter.