### PR TITLE
do_while: note absence of break/continue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,8 @@ macro_rules! unwrap_or_return {
 /// assert!(ran);
 /// # }
 /// ```
+///
+/// The loop control statements `break` and `continue` are unavailable.
 #[macro_export]
 macro_rules! do_while {
     ($body:block while $condition:expr) => {


### PR DESCRIPTION
It's a neat hack, but not having break/cont is bit of a PITA. Maybe I should go straight to a PR for loop { $body; if ! ($condition) { break; } } instead? (I also want to add the three-pronged for. Old-fashioned me.)